### PR TITLE
Add examples and notes to schema

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -202,6 +202,10 @@ export default function convert(joi,transformer=null) {
   if (joi._description) {
     schema.description = joi._description;
   }
+  
+  if (joi._examples.length > 0) {
+    schema.examples = joi._examples;
+  }
 
   // Add the label as a title if it exists
   if (joi._settings && joi._settings.language && joi._settings.language.label) {

--- a/src/index.js
+++ b/src/index.js
@@ -206,6 +206,10 @@ export default function convert(joi,transformer=null) {
   if (joi._examples.length > 0) {
     schema.examples = joi._examples;
   }
+  
+  if (joi._notes.length > 0) {
+    schema.notes = joi._notes;
+  }
 
   // Add the label as a title if it exists
   if (joi._settings && joi._settings.language && joi._settings.language.label) {


### PR DESCRIPTION
Some Joi objects can use examples and notes, we should be able to have them in the json like the description.
