### PR TITLE
Fix default value handling for false and 0 values

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ which will produce:
   properties: 
    { name: { type: 'string', pattern: '^\\w+$' },
      description: { default: 'no description provided', type: 'string' },
-     a: { type: 'boolean' },
-     b: { oneOf: [ { default: 'a is true', type: 'string' }, { type: 'number' } ] } },
+     a: { type: 'boolean', default: false },
+     b: { oneOf: [ { default: 'a is true', type: 'string' }, { type: 'number', default: 0 } ] } },
   additionalProperties: false,
   required: [ 'name', 'a' ] }
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -208,7 +208,8 @@ export default function convert(joi,transformer=null) {
     schema.title = joi._settings.language.label;
   }
 
-  if (joi._flags && joi._flags.default) {
+  // Checking for undefined and null explicitly to allow false and 0 values
+  if (joi._flags && joi._flags.default !== undefined && joi._flags.default !== null) {
     schema['default'] = joi._flags.default;
   }
 

--- a/test/convert_test.js
+++ b/test/convert_test.js
@@ -413,14 +413,18 @@ suite('convert', function () {
         expected = {
           type: 'object',
           properties: {
-            a: {type: 'boolean'},
+            a: {
+              type: 'boolean',
+              default: false
+            },
             b: {
               oneOf: [
                 {
                   'default': 'a is true',
                   type: 'string'
                 }, {
-                  type: 'number'
+                  type: 'number',
+                  default: 0
                 }
               ]
             }


### PR DESCRIPTION
`if (joi._flags && joi._flags.default) ` 
would not let through false (boolean) and 0 (number) values,
added explicit check for undefined and null to fix it