### PR TITLE
Correct support for any.label() (in addition to any.options.language.label)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -206,6 +206,8 @@ export default function convert(joi,transformer=null) {
   // Add the label as a title if it exists
   if (joi._settings && joi._settings.language && joi._settings.language.label) {
     schema.title = joi._settings.language.label;
+  } else if (joi._flags && joi._flags.label) {
+    schema.title = joi._flags.label;
   }
 
   // Checking for undefined and null explicitly to allow false and 0 values

--- a/test/convert_test.js
+++ b/test/convert_test.js
@@ -42,6 +42,18 @@ suite('convert', function () {
           type: 'object',
           title: 'Title',
           properties: {},
+          additionalProperties: false
+        };
+    assert.validate(schema, expected);
+  });
+
+  test('object options language label', function () {
+    var joi = Joi.object().options({language:{label: 'Title'}}),
+        schema = convert(joi),
+        expected = {
+          type: 'object',
+          title: 'Title',
+          properties: {},
           additionalProperties: false,
         };
     assert.validate(schema, expected);


### PR DESCRIPTION
- Adding support for 'any.label()' joi functionality and accompanying test. https://github.com/hapijs/joi/blob/v9.2.0/API.md#anylabelname

- Fixed test from commit https://github.com/FirstLineMedical/joi-to-json-schema/commit/ca54f53830fadaa2ae503d69f01e9400255d9a92