### PR TITLE
Add'l properties are actually disllowed unless explicitly allowed.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -154,7 +154,7 @@ let TYPES = {
   object: (schema, joi) => {
     schema.type = 'object';
     schema.properties = {};
-    schema.additionalProperties = joi._flags.allowUnknown !== false;
+    schema.additionalProperties = Boolean(joi._flags.allowUnknown);
     schema.patterns = joi._inner.patterns.map((pattern) => {
       return {regex: pattern.regex, rule: convert(pattern.rule)};
     });

--- a/test/convert_test.js
+++ b/test/convert_test.js
@@ -31,7 +31,7 @@ suite('convert', function () {
           type: 'object',
           properties: {},
           patterns: [],
-          additionalProperties: true
+          additionalProperties: false,
         };
     assert.validate(schema, expected);
   });
@@ -44,7 +44,7 @@ suite('convert', function () {
           title: 'Title',
           properties: {},
           patterns: [],
-          additionalProperties: true
+          additionalProperties: false,
         };
     assert.validate(schema, expected);
   });
@@ -57,7 +57,7 @@ suite('convert', function () {
           title: 'Title',
           properties: {},
           patterns: [],
-          additionalProperties: true,
+          additionalProperties: false,
         };
     assert.validate(schema, expected);
   });
@@ -69,7 +69,7 @@ suite('convert', function () {
           type: 'object',
           properties: {},
           patterns: [],
-          additionalProperties: true,
+          additionalProperties: false,
           description: 'woot'
         };
     assert.validate(schema, expected);
@@ -82,7 +82,7 @@ suite('convert', function () {
           type: 'object',
           properties: {},
           patterns: [],
-          additionalProperties: false
+          additionalProperties: false,
         };
     assert.validate(schema, expected);
   });
@@ -126,7 +126,7 @@ suite('convert', function () {
             }
           },
           patterns: [],
-          additionalProperties: true
+          additionalProperties: false
         };
     assert.validate(schema, expected);
   });
@@ -159,7 +159,7 @@ suite('convert', function () {
             }
           },
           patterns: [],
-          additionalProperties: true
+          additionalProperties: false
         };
     assert.validate(schema, expected);
   });
@@ -189,7 +189,7 @@ suite('convert', function () {
             }
           },
           patterns: [],
-          additionalProperties: true
+          additionalProperties: false,
         };
     assert.validate(schema, expected);
   });
@@ -226,7 +226,7 @@ suite('convert', function () {
         expected = {
           type: 'object',
           patterns: [],
-          additionalProperties: true,
+          additionalProperties: false,
           properties: {
             value: {
               oneOf: [
@@ -473,7 +473,7 @@ suite('convert', function () {
             }
           },
           patterns: [],
-          additionalProperties: true,
+          additionalProperties: false,
           required: ['a']
         };
     //console.log('when: %s', util.inspect({type:joi._type,schema:schema}, {depth: 10}));

--- a/test/fixtures/complicated.json
+++ b/test/fixtures/complicated.json
@@ -43,7 +43,7 @@
       ]
     }
   },
-  "additionalProperties": true,
+  "additionalProperties": false,
   "patterns": [],
   "required": [
     "anInt"

--- a/test/fixtures/transform.json
+++ b/test/fixtures/transform.json
@@ -28,7 +28,7 @@
                   "type": "string"
                 }
               },
-              "additionalProperties": true,
+              "additionalProperties": false,
               "patterns": [],
               "required": [
                 "name",
@@ -57,7 +57,7 @@
                   "maximum": 20
                 }
               },
-              "additionalProperties": true,
+              "additionalProperties": false,
               "patterns": [],
               "required": [
                 "name",
@@ -78,7 +78,7 @@
       ]
     }
   },
-  "additionalProperties": true,
+  "additionalProperties": false,
   "patterns": [],
   "required": [
     "name",


### PR DESCRIPTION
I read the docs wrong and didn't test it right. This essentially reverts commit 3d91f6660dc5a7e3e0f1638dca291040e39b6628.