### PR TITLE
Fix array item schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /node_modules
 /build
 /tmp
+npm-debug.log

--- a/src/index.js
+++ b/src/index.js
@@ -84,7 +84,7 @@ let TYPES = {
       }
 
       if (list) {
-        schema.items = list.map((item) => convert(item));
+        schema.items = convert(list[0]);
       }
     }
 

--- a/test/convert_test.js
+++ b/test/convert_test.js
@@ -390,7 +390,7 @@ suite('convert', function () {
         schema = convert(joi),
         expected = {
           type: 'array',
-          items: [{type: 'string'}]
+          items: {type: 'string'}
         };
     assert.validate(schema, expected);
   });
@@ -481,4 +481,3 @@ suite('convert', function () {
   });
 
 });
-

--- a/test/fixtures/complicated.json
+++ b/test/fixtures/complicated.json
@@ -18,29 +18,25 @@
     },
     "anArrayOfFloats": {
       "type": "array",
-      "items": [
-        {
-          "default": 0.8,
-          "type": "number",
-          "minimum": 0,
-          "maximum": 1
-        }
-      ]
+      "items": {
+        "default": 0.8,
+        "type": "number",
+        "minimum": 0,
+        "maximum": 1
+      }
     },
     "anArrayOfNumbersOrStrings": {
       "type": "array",
-      "items": [
-        {
-          "oneOf": [
-            {
-              "type": "number"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        }
-      ]
+      "items": {
+        "oneOf": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      }
     }
   },
   "additionalProperties": true,


### PR DESCRIPTION
I'm not sure why, but original array schema cannot work with swagger,
and check out this: https://github.com/json-schema-org/json-schema-org.github.io/blob/master/example2.html#L193 the specification also doesn't use an array of schema to present items schema of an array.