### PR TITLE
Added timestamp support && Make compatibility with latest Joi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "0.12"
-  - "0.11"
-  - "0.10"
-  - "iojs"
+  - node # latest stable Node.js release
+  - "lts/*" # latest LTS Node.js release, currently, active lts version is 6.
+  - 4 # Minimum node.js version that yarn supported

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,5 @@ language: node_js
 node_js:
   - node # latest stable Node.js release
   - "lts/*" # latest LTS Node.js release, currently, active lts version is 6.
-  - 4 # Minimum node.js version that yarn supported
 install:
   - yarn --ignore-engines

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,5 @@ node_js:
   - node # latest stable Node.js release
   - "lts/*" # latest LTS Node.js release, currently, active lts version is 6.
   - 4 # Minimum node.js version that yarn supported
+install:
+  - yarn --ignore-engines

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "babel-cli": "^6.24.0",
     "babel-preset-latest": "^6.24.0",
     "babel-register": "^6.24.0",
-    "joi": "^13.0.1",
+    "joi": "^12.0.0",
     "json-schema": "^0.2.2",
     "lodash": "^3.10.1",
     "mocha": "^2.5.3"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "babel-cli": "^6.24.0",
     "babel-preset-latest": "^6.24.0",
     "babel-register": "^6.24.0",
-    "joi": "^12.0.0",
+    "joi": "^13.0.1",
     "json-schema": "^0.2.2",
     "lodash": "^3.10.1",
     "mocha": "^2.5.3"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,13 @@
   "maintainers": [
     "Rob Raisch [:raisch]"
   ],
+  "contributors": [
+    {
+      "name" : "MooYeol Prescott Lee",
+      "email" : "mooyoul@gmail.com",
+      "url" : "https://github.com/mooyoul"
+    }
+  ],
   "license": "Apache2",
   "bugs": {
     "url": "https://github.com/lightsofapollo/joi-to-json-schema/issues"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "babel-cli": "^6.24.0",
     "babel-preset-latest": "^6.24.0",
     "babel-register": "^6.24.0",
-    "joi": "^6.10.1",
+    "joi": "^13.0.1",
     "json-schema": "^0.2.2",
     "lodash": "^3.10.1",
     "mocha": "^2.5.3"

--- a/src/index.js
+++ b/src/index.js
@@ -131,7 +131,19 @@ let TYPES = {
           schema.format = 'email';
           break;
         case 'regex':
-          schema.pattern = String(test.arg).replace(/^\//,'').replace(/\/$/,'');
+          // for backward compatibility
+          const arg = test.arg;
+
+          // This is required for backward compatibility
+          // Location "pattern" had changed since Joi v9.0.0
+          //
+          // For example:
+          //
+          // before Joi v9: test.arg
+          // since Joi v9: test.arg.pattern
+
+          const pattern = arg && arg.pattern ? arg.pattern : arg;
+          schema.pattern = String(pattern).replace(/^\//,'').replace(/\/$/,'');
           break;
         case 'min':
           schema.minLength = test.arg;

--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,12 @@ let TYPES = {
     return schema;
   },
 
-  date: (schema) => {
+  date: (schema, joi) => {
+    if (joi._flags.timestamp) {
+      schema.type = 'integer';
+      return schema;
+    }
+
     schema.type = 'string';
     schema.format = 'date-time';
     return schema;

--- a/test/convert_test.js
+++ b/test/convert_test.js
@@ -312,6 +312,24 @@ suite('convert', function () {
     assert.validate(schema, expected);
   });
 
+  test('date (javascript timestamp)', function () {
+    var joi = Joi.date().timestamp(),
+        schema = convert(joi),
+        expected = {
+          type: 'integer',
+        };
+    assert.validate(schema, expected);
+  });
+
+  test('date (unix timestamp)', function () {
+    var joi = Joi.date().timestamp('unix'),
+      schema = convert(joi),
+      expected = {
+        type: 'integer',
+      };
+    assert.validate(schema, expected);
+  });
+
   test('string regex -> pattern', function () {
     let joi = Joi.string().regex(/^[a-z]$/),
         schema = convert(joi),

--- a/yarn.lock
+++ b/yarn.lock
@@ -957,6 +957,10 @@ hoek@2.x.x:
   version "2.16.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
 
+hoek@5.x.x:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/hoek/-/hoek-5.0.0.tgz#b88953e0fec8e58082e4abd223ed20915d535831"
+
 home-or-tmp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
@@ -1061,9 +1065,11 @@ isarray@1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
 
-isemail@1.x.x:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/isemail/-/isemail-1.2.0.tgz#be03df8cc3e29de4d2c5df6501263f1fa4595e9a"
+isemail@3.x.x:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/isemail/-/isemail-3.0.0.tgz#c89a46bb7a3361e1759f8028f9082488ecce3dff"
+  dependencies:
+    punycode "2.x.x"
 
 isobject@^2.0.0:
   version "2.1.0"
@@ -1088,14 +1094,13 @@ jodid25519@^1.0.0:
   dependencies:
     jsbn "~0.1.0"
 
-joi@^6.10.1:
-  version "6.10.1"
-  resolved "https://registry.yarnpkg.com/joi/-/joi-6.10.1.tgz#4d50c318079122000fe5f16af1ff8e1917b77e06"
+joi@^13.0.1:
+  version "13.0.1"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-13.0.1.tgz#97df285450e3ff5bc4db9eccf40a1cd5cf3ec189"
   dependencies:
-    hoek "2.x.x"
-    isemail "1.x.x"
-    moment "2.x.x"
-    topo "1.x.x"
+    hoek "5.x.x"
+    isemail "3.x.x"
+    topo "3.x.x"
 
 js-tokens@^3.0.0:
   version "3.0.1"
@@ -1242,10 +1247,6 @@ mocha@^2.5.3:
     supports-color "1.2.0"
     to-iso-string "0.0.2"
 
-moment@2.x.x:
-  version "2.18.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
-
 ms@0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.1.tgz#9cd13c03adbff25b65effde7ce864ee952017098"
@@ -1366,6 +1367,10 @@ private@^0.1.6:
 process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
+
+punycode@2.x.x:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.0.tgz#5f863edc89b96db09074bad7947bf09056ca4e7d"
 
 punycode@^1.4.1:
   version "1.4.1"
@@ -1628,11 +1633,11 @@ to-iso-string@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/to-iso-string/-/to-iso-string-0.0.2.tgz#4dc19e664dfccbe25bd8db508b00c6da158255d1"
 
-topo@1.x.x:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/topo/-/topo-1.1.0.tgz#e9d751615d1bb87dc865db182fa1ca0a5ef536d5"
+topo@3.x.x:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/topo/-/topo-3.0.0.tgz#37e48c330efeac784538e0acd3e62ca5e231fe7a"
   dependencies:
-    hoek "2.x.x"
+    hoek "5.x.x"
 
 tough-cookie@~2.3.0:
   version "2.3.2"


### PR DESCRIPTION
## Summary

I've added timestamp (Joi.date().timestamp()) support and made compatibility with latest Joi, without losing backward compatibility (Joi v6.10.1 for example)


### Changes

1. fixed broken `Joi.string().regex()` support with latest Joi
2. bump joi dev dependency version
3. added  `Joi.date().timestamp()` support

### Affected Issues

Closes #13
Closes #20
Closes #27 