### PR TITLE
Add support for example (singular) when there is only one example.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "joi-to-json-schema",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Joi -> JSON Schema Converter",
   "main": "build/index.js",
   "scripts": {
@@ -25,9 +25,9 @@
   ],
   "contributors": [
     {
-      "name" : "MooYeol Prescott Lee",
-      "email" : "mooyoul@gmail.com",
-      "url" : "https://github.com/mooyoul"
+      "name": "MooYeol Prescott Lee",
+      "email": "mooyoul@gmail.com",
+      "url": "https://github.com/mooyoul"
     }
   ],
   "license": "Apache2",

--- a/src/index.js
+++ b/src/index.js
@@ -226,6 +226,10 @@ export default function convert(joi,transformer=null) {
 
   if (joi._examples && joi._examples.length > 0) {
     schema.examples = joi._examples;
+  } 
+  
+  if (joi._examples && joi._examples.length === 1) {
+    schema.example = joi._examples[0];
   }
 
   // Add the label as a title if it exists

--- a/test/convert_test.js
+++ b/test/convert_test.js
@@ -83,6 +83,7 @@ suite('convert', function () {
           properties: {},
           patterns: [],
           additionalProperties: false,
+          example: { key: 'value' },
           examples: [{ key: 'value' }]
         };
     assert.validate(schema, expected);


### PR DESCRIPTION
openapi has syntax for both `example` and `examples` depending on which type of object is being defined. I wanted to preserve the previous functionality that was contributed (i.e. examples) while also adding support for examples.