### PR TITLE
Support both example (singular) and examples

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -226,6 +226,10 @@ export default function convert(joi,transformer=null) {
 
   if (joi._examples && joi._examples.length > 0) {
     schema.examples = joi._examples;
+  } 
+  
+  if (joi._examples && joi._examples.length === 1) {
+    schema.example = joi._examples[0];
   }
 
   // Add the label as a title if it exists

--- a/test/convert_test.js
+++ b/test/convert_test.js
@@ -83,6 +83,7 @@ suite('convert', function () {
           properties: {},
           patterns: [],
           additionalProperties: false,
+          example: { key: 'value' },
           examples: [{ key: 'value' }]
         };
     assert.validate(schema, expected);


### PR DESCRIPTION
openapi has syntax for both example and examples depending on which type of object is being defined. I wanted to preserve the previous functionality that was contributed (i.e. examples) while also adding support for examples.

https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md