### PR TITLE
Call the transformer recursively, and pass it the Joi schema

### DIFF
--- a/test/transformer_test.js
+++ b/test/transformer_test.js
@@ -113,4 +113,42 @@ suite('transform', function () {
     assert.validate(schema, expected);
   });
 
+  test('recursive transforms', function () {
+    var joi = Joi.object().keys({
+          foo: Joi.object().keys({
+            bar: Joi.string().meta({ jsonSchema: { propertyOrder: 100 } }),
+          }),
+        }),
+        transformer = function (obj, joi) {
+          if (joi._meta) {
+            joi._meta.forEach(function(meta) {
+              if (meta.jsonSchema) {
+                obj = Object.assign({}, obj, meta.jsonSchema)
+              }
+            })
+          }
+
+          return obj;
+        },
+        schema = convert(joi, transformer),
+        expected = {
+          type: 'object',
+          properties: {
+            foo: {
+              type: "object",
+              properties: {
+                bar: {
+                  type: "string",
+                  propertyOrder: 100
+                }
+              },
+              patterns: [],
+              additionalProperties: false
+            },
+          },
+          patterns: [],
+          additionalProperties: false
+        };
+    assert.validate(schema, expected);
+  });
 });


### PR DESCRIPTION
My use case: I wanted to be able to attach JSON schema-specific
information to particular items in the Joi object, using Joi's `.meta()`
method. However, this wasn't possible, since `convert()` doesn't pass
the transformer to itself recursively. Furthermore, the transformer
needed access to the Joi schema object for the particular part of the
tree that it is transforming, so that it could inspect the `joi._meta`
property for the keys I'd added via `.meta()`.

This PR makes this possible by A) making sure the transform function is
passed around recursively, and B) passing the `joi` object to the
transform function.