### PR TITLE
Add support for joi binary type

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -96,6 +96,13 @@ let TYPES = {
     return schema;
   },
 
+  binary: (schema, joi) => {
+    schema.type = 'string';
+    schema.contentMediaType = joi._meta.length > 0 && joi._meta[0].contentMediaType ? joi._meta[0].contentMediaType : 'text/plain';
+    schema.contentEncoding = joi._flags.encoding ? joi._flags.encoding : 'binary';
+    return schema;
+  },
+
   boolean: (schema) => {
     schema.type = 'boolean';
     return schema;

--- a/test/convert_test.js
+++ b/test/convert_test.js
@@ -446,6 +446,28 @@ suite('convert', function () {
     assert.validate(schema, expected);
   });
 
+  test('joi binary with content encoding', function () {
+    let joi = Joi.binary().encoding('base64'),
+      schema = convert(joi),
+      expected = {
+        type: 'string',
+        contentMediaType: 'text/plain',
+        contentEncoding: 'base64'
+      };
+    assert.validate(schema, expected);
+  });
+
+  test('joi binary with content type', function () {
+    let joi = Joi.binary().meta({ contentMediaType: 'image/png' }),
+      schema = convert(joi),
+      expected = {
+        type: 'string',
+        contentMediaType: 'image/png',
+        contentEncoding: 'binary'
+      };
+    assert.validate(schema, expected);
+  });
+
   test('big and complicated', function () {
     let joi = Joi.object({
           aFormattedString: Joi.string().regex(/^[ABC]_\w+$/),


### PR DESCRIPTION
In the case of using Joi to validate HTTP request data, binary data can be included when uploading file.

As JSON schema doesn't contain Buffer data type directly, it supports [String-Encoding Non-Json Data](https://json-schema.org/latest/json-schema-validation.html#rfc.section.8).

This PR would like to add support for this case.