### PR TITLE
Joi.object() should accept all keys

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -187,7 +187,7 @@ let TYPES = {
   object: (schema, joi, transformer) => {
     schema.type = 'object';
     schema.properties = {};
-    schema.additionalProperties = Boolean(joi._flags.allowUnknown);
+    schema.additionalProperties = Boolean(joi._flags.allowUnknown || (joi._flags.allowUnknown === undefined && !joi._inner.children));
     schema.patterns = joi._inner.patterns.map((pattern) => {
       return {regex: pattern.regex, rule: convert(pattern.rule, transformer)};
     });

--- a/src/index.js
+++ b/src/index.js
@@ -187,7 +187,7 @@ let TYPES = {
   object: (schema, joi, transformer) => {
     schema.type = 'object';
     schema.properties = {};
-    schema.additionalProperties = Boolean(joi._flags.allowUnknown || (joi._flags.allowUnknown === undefined && !joi._inner.children));
+    schema.additionalProperties = Boolean(joi._flags.allowUnknown || !joi._inner.children);
     schema.patterns = joi._inner.patterns.map((pattern) => {
       return {regex: pattern.regex, rule: convert(pattern.rule, transformer)};
     });

--- a/test/convert_test.js
+++ b/test/convert_test.js
@@ -31,6 +31,18 @@ suite('convert', function () {
           type: 'object',
           properties: {},
           patterns: [],
+          additionalProperties: true,
+        };
+    assert.validate(schema, expected);
+  });
+
+  test('empty object will not allow additional properties', function () {
+    var joi = Joi.object({}),
+        schema = convert(joi),
+        expected = {
+          type: 'object',
+          properties: {},
+          patterns: [],
           additionalProperties: false,
         };
     assert.validate(schema, expected);
@@ -44,7 +56,7 @@ suite('convert', function () {
           title: 'Title',
           properties: {},
           patterns: [],
-          additionalProperties: false,
+          additionalProperties: true,
         };
     assert.validate(schema, expected);
   });
@@ -57,7 +69,7 @@ suite('convert', function () {
           title: 'Title',
           properties: {},
           patterns: [],
-          additionalProperties: false,
+          additionalProperties: true,
         };
     assert.validate(schema, expected);
   });
@@ -69,7 +81,7 @@ suite('convert', function () {
           type: 'object',
           properties: {},
           patterns: [],
-          additionalProperties: false,
+          additionalProperties: true,
           description: 'woot'
         };
     assert.validate(schema, expected);
@@ -82,7 +94,7 @@ suite('convert', function () {
           type: 'object',
           properties: {},
           patterns: [],
-          additionalProperties: false,
+          additionalProperties: true,
           example: { key: 'value' },
           examples: [{ key: 'value' }]
         };

--- a/test/convert_test.js
+++ b/test/convert_test.js
@@ -108,7 +108,7 @@ suite('convert', function () {
           type: 'object',
           properties: {},
           patterns: [],
-          additionalProperties: false,
+          additionalProperties: true,
         };
     assert.validate(schema, expected);
   });


### PR DESCRIPTION
Another odd edge case for joi (tested on v13.0.5). When given no explicit keys or patterns Joi.object() will allow any key even when `unknown(false)` is specified. Examples:
```
const schema = Joi.object();
Joi.attempt({ extraKey: 'I am not in the schema' }, schema) // no error this is allowed

const schema = Joi.object().unknown(false);
Joi.attempt({ extraKey: 'I am not in the schema' }, schema) // no error this is also allowed
```